### PR TITLE
Ayo prescreening task 

### DIFF
--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -244,7 +244,7 @@ benchmarks! {
         DappsStaking::<T>::set_reward_destination(RawOrigin::Signed(staker.clone()).into(), RewardDestination::StakeBalance)?;
         advance_to_era::<T>(claim_era + 1u32);
 
-    }: claim_staker(RawOrigin::Signed(staker.clone()), contract_id.clone())
+    }: claim_staker(RawOrigin::Signed(staker.clone()), contract_id.clone(), None)
     verify {
         let mut staker_info = DappsStaking::<T>::staker_info(&staker, &contract_id);
         let (era, _) = staker_info.claim();
@@ -263,7 +263,7 @@ benchmarks! {
         DappsStaking::<T>::set_reward_destination(RawOrigin::Signed(staker.clone()).into(), RewardDestination::FreeBalance)?;
         advance_to_era::<T>(claim_era + 1u32);
 
-    }: claim_staker(RawOrigin::Signed(staker.clone()), contract_id.clone())
+    }: claim_staker(RawOrigin::Signed(staker.clone()), contract_id.clone(), None)
     verify {
         let mut staker_info = DappsStaking::<T>::staker_info(&staker, &contract_id);
         let (era, _) = staker_info.claim();

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, HasCompact};
+use codec::{Decode, Encode, HasCompact, MaxEncodedLen};
 use frame_support::traits::Currency;
 use frame_system::{self as system};
 use scale_info::TypeInfo;
@@ -500,6 +500,16 @@ impl Default for RewardDestination {
     fn default() -> Self {
         RewardDestination::StakeBalance
     }
+}
+
+/// contains information about each beneficiary for a particular staker
+#[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub struct RewardBeneficiary<AccountId, Balance: HasCompact + MaxEncodedLen> {
+    /// Account delegated to which rewards are deposited.
+    pub account: AccountId,
+    /// Amount of rewards deposited.
+     #[codec(compact)]
+    pub amount: Balance,
 }
 
 /// Contains information about account's locked & unbonding balances.

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -496,7 +496,7 @@ pub enum RewardDestination {
     /// Rewards are transferred to stakers balance and are immediately re-staked
     /// on the contract from which the reward was received.
     StakeBalance,
-    /// Rewards are deposited into a delegated beneficiary account.
+    /// This indicates that the Rewards are deposited into a delegated beneficiary account.
     BeneficiaryBalance,
 }
 
@@ -505,61 +505,14 @@ impl Default for RewardDestination {
         RewardDestination::StakeBalance
     }
 }
-
-#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-pub enum EmbededDestination<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
-    #[default]
-    None,
-    Destination {
-        who: AccountId,
-        amount: Balance,
-    },
-}
-
-#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-
-pub enum SmartContractAddress<SmartContract> {
-    #[default]
-    None,
-    Address(SmartContract),
-}
-
-#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-
-pub enum DelegatedAddress<AccountId> {
-    #[default]
-    None,
-    Address(AccountId),
-}
-
 /// contains information about each beneficiary for a particular staker
-#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
-
-pub struct RewardBeneficiary<SmartContract, Balance: AtLeast32BitUnsigned + Default + Copy> {
-    /// Amount of rewards deposited.
-    #[codec(compact)]
-    pub amount: Balance,
-    // smart contract the staker was awarded from after staking on the contract
-    pub contract_id: SmartContractAddress<SmartContract>,
-    // indicates whether the beneficiary is active or not
-    pub active: bool,
-}
-
 #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct BeneficiaryReward<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
     /// Amount of rewards deposited.
     #[codec(compact)]
     pub amount: Balance,
-
+    /// The account of the beneficiary
     pub account: AccountId,
-    // indicates whether the beneficiary is active or not
-    // pub active: bool,
-}
-
-#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
-pub struct BeneficiaryInfo<AccountId> {
-    pub account: AccountId,
-    pub active: bool,
 }
 
 /// Contains information about account's locked & unbonding balances.

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -545,6 +545,17 @@ pub struct RewardBeneficiary<SmartContract, Balance: AtLeast32BitUnsigned + Defa
     pub active: bool,
 }
 
+#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+pub struct BeneficiaryReward<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
+    /// Amount of rewards deposited.
+    #[codec(compact)]
+    pub amount: Balance,
+
+    pub account: AccountId,
+    // indicates whether the beneficiary is active or not
+    // pub active: bool,
+}
+
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct BeneficiaryInfo<AccountId> {
     pub account: AccountId,
@@ -552,7 +563,7 @@ pub struct BeneficiaryInfo<AccountId> {
 }
 
 /// Contains information about account's locked & unbonding balances.
-#[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct AccountLedger<Balance: AtLeast32BitUnsigned + Default + Copy> {
     /// Total balance locked.
     #[codec(compact)]
@@ -561,6 +572,16 @@ pub struct AccountLedger<Balance: AtLeast32BitUnsigned + Default + Copy> {
     unbonding_info: UnbondingInfo<Balance>,
     /// Instruction on how to handle reward payout
     reward_destination: RewardDestination,
+}
+
+impl<Balance: AtLeast32BitUnsigned + Default + Copy> Default for AccountLedger<Balance> {
+    fn default() -> Self {
+        AccountLedger {
+            locked: Balance::default(),
+            unbonding_info: UnbondingInfo::default(),
+            reward_destination: RewardDestination::default(),
+        }
+    }
 }
 
 impl<Balance: AtLeast32BitUnsigned + Default + Copy> AccountLedger<Balance> {

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -503,10 +503,13 @@ impl Default for RewardDestination {
 }
 
 #[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-pub enum EmbededDestination<AccountId> {
+pub enum EmbededDestination<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
     #[default]
     None,
-    Destination(AccountId),
+    Destination {
+        who: AccountId,
+        amount: Balance,
+    },
 }
 
 /// contains information about each beneficiary for a particular staker
@@ -514,7 +517,7 @@ pub enum EmbededDestination<AccountId> {
 
 pub struct RewardBeneficiary<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
     /// next reward destination
-    pub next: EmbededDestination<AccountId>,
+    pub next: EmbededDestination<AccountId, Balance>,
     /// Amount of rewards deposited.
     #[codec(compact)]
     pub amount: Balance,

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -494,6 +494,8 @@ pub enum RewardDestination {
     /// Rewards are transferred to stakers balance and are immediately re-staked
     /// on the contract from which the reward was received.
     StakeBalance,
+    /// Rewards are deposited into a delegated beneficiary account.
+    BeneficiaryBalance
 }
 
 impl Default for RewardDestination {

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -49,11 +49,9 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, HasCompact, MaxEncodedLen};
+use codec::{Decode, Encode, HasCompact};
 use frame_support::traits::Currency;
 use frame_system::{self as system};
-// use mock::AccountId;
-use pallet_balances::Account;
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{AtLeast32BitUnsigned, Zero},

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -190,7 +190,7 @@ impl Default for Version {
 
 /// Used to represent how much was staked in a particular era.
 /// E.g. `{staked: 1000, era: 5}` means that in era `5`, staked amount was 1000.
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct EraStake<Balance: AtLeast32BitUnsigned + Copy> {
     /// Staked amount in era
     #[codec(compact)]
@@ -238,9 +238,11 @@ impl<Balance: AtLeast32BitUnsigned + Copy> EraStake<Balance> {
 pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy> {
     // Size of this list would be limited by a configurable constant
     stakes: Vec<EraStake<Balance>>,
+    // Size of this list would be limited by a configurable constant
+    // pub beneficiaries: Vec<BeneficiaryInfo<AccountId, Balance>>,
 }
 
-impl<Balance: AtLeast32BitUnsigned + Copy> StakerInfo<Balance> {
+impl<Balance: AtLeast32BitUnsigned + Copy + Default> StakerInfo<Balance> {
     /// `true` if no active stakes and unclaimed eras exist, `false` otherwise
     fn is_empty(&self) -> bool {
         self.stakes.is_empty()
@@ -495,7 +497,7 @@ pub enum RewardDestination {
     /// on the contract from which the reward was received.
     StakeBalance,
     /// Rewards are deposited into a delegated beneficiary account.
-    BeneficiaryBalance
+    BeneficiaryBalance,
 }
 
 impl Default for RewardDestination {
@@ -514,16 +516,65 @@ pub enum EmbededDestination<AccountId, Balance: AtLeast32BitUnsigned + Default +
     },
 }
 
+#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+
+pub enum SmartContractAddress<SmartContract> {
+    #[default]
+    None,
+    Address(SmartContract),
+}
+
+#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+
+pub enum DelegatedAddress<AccountId> {
+    #[default]
+    None,
+    Address(AccountId),
+}
+
 /// contains information about each beneficiary for a particular staker
 #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 
-pub struct RewardBeneficiary<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
-    /// next reward destination
-    pub next: EmbededDestination<AccountId, Balance>,
+pub struct RewardBeneficiary<SmartContract, Balance: AtLeast32BitUnsigned + Default + Copy> {
     /// Amount of rewards deposited.
     #[codec(compact)]
     pub amount: Balance,
+    // smart contract the staker was awarded from after staking on the contract
+    pub contract_id: SmartContractAddress<SmartContract>,
+    // indicates whether the beneficiary is active or not
+    pub active: bool,
 }
+
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
+pub struct BeneficiaryInfo<AccountId> {
+    pub account: AccountId,
+    pub active: bool,
+}
+
+// #[derive(Clone, PartialEq, Eq, Encode, Default, Decode, RuntimeDebug, TypeInfo)]
+
+// pub struct Beneficiaries<AccountId> {
+//     pub list_of_beneficiaries: Vec<AccountOfBeneficiary<AccountId>>,
+// }
+
+// #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+
+// pub struct BeneficiaryInfo<SmartContract, AccountId, Balance: AtLeast32BitUnsigned + Copy + Default>
+// {
+//     /// staker account address
+//     pub staker: AccountId,
+//     // indicates whether the beneficiary is active or not
+//     pub active: bool,
+//     //beneficiary account address
+//     pub beneficiary_account: AccountId,
+//     /// Amount of rewards deposited into the beneficiary account.
+//     #[codec(compact)]
+//     pub amount: Balance,
+//     // smart contract the staker was awarded from after staking on the contract
+//     pub contract_id: SmartContractAddress<SmartContract>,
+//     // delegated account address
+//     pub delegated_beneficiary: DelegatedAddress<AccountId>,
+// }
 
 /// Contains information about account's locked & unbonding balances.
 #[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -551,31 +551,6 @@ pub struct BeneficiaryInfo<AccountId> {
     pub active: bool,
 }
 
-// #[derive(Clone, PartialEq, Eq, Encode, Default, Decode, RuntimeDebug, TypeInfo)]
-
-// pub struct Beneficiaries<AccountId> {
-//     pub list_of_beneficiaries: Vec<AccountOfBeneficiary<AccountId>>,
-// }
-
-// #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
-
-// pub struct BeneficiaryInfo<SmartContract, AccountId, Balance: AtLeast32BitUnsigned + Copy + Default>
-// {
-//     /// staker account address
-//     pub staker: AccountId,
-//     // indicates whether the beneficiary is active or not
-//     pub active: bool,
-//     //beneficiary account address
-//     pub beneficiary_account: AccountId,
-//     /// Amount of rewards deposited into the beneficiary account.
-//     #[codec(compact)]
-//     pub amount: Balance,
-//     // smart contract the staker was awarded from after staking on the contract
-//     pub contract_id: SmartContractAddress<SmartContract>,
-//     // delegated account address
-//     pub delegated_beneficiary: DelegatedAddress<AccountId>,
-// }
-
 /// Contains information about account's locked & unbonding balances.
 #[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
 pub struct AccountLedger<Balance: AtLeast32BitUnsigned + Default + Copy> {

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -52,6 +52,8 @@
 use codec::{Decode, Encode, HasCompact, MaxEncodedLen};
 use frame_support::traits::Currency;
 use frame_system::{self as system};
+// use mock::AccountId;
+use pallet_balances::Account;
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{AtLeast32BitUnsigned, Zero},
@@ -502,13 +504,21 @@ impl Default for RewardDestination {
     }
 }
 
+#[derive(Encode, Decode, Clone, Copy, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+pub enum EmbededDestination<AccountId> {
+    #[default]
+    None,
+    Destination(AccountId),
+}
+
 /// contains information about each beneficiary for a particular staker
-#[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-pub struct RewardBeneficiary<AccountId, Balance: HasCompact + MaxEncodedLen> {
-    /// Account delegated to which rewards are deposited.
-    pub account: AccountId,
+#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+
+pub struct RewardBeneficiary<AccountId, Balance: AtLeast32BitUnsigned + Default + Copy> {
+    /// next reward destination
+    pub next: EmbededDestination<AccountId>,
     /// Amount of rewards deposited.
-     #[codec(compact)]
+    #[codec(compact)]
     pub amount: Balance,
 }
 

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -31,7 +31,7 @@ pub(crate) const MINIMUM_REMAINING_AMOUNT: Balance = 1;
 pub(crate) const MAX_UNLOCKING_CHUNKS: u32 = 4;
 pub(crate) const UNBONDING_PERIOD: EraIndex = 3;
 pub(crate) const MAX_ERA_STAKE_VALUES: u32 = 8;
-pub(crate) const MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER: u32 = 4;
+pub(crate) const MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER: u32 = 10;
 
 // Do note that this needs to at least be 3 for tests to be valid. It can be greater but not smaller.
 pub(crate) const BLOCKS_PER_ERA: BlockNumber = 3;

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -31,6 +31,7 @@ pub(crate) const MINIMUM_REMAINING_AMOUNT: Balance = 1;
 pub(crate) const MAX_UNLOCKING_CHUNKS: u32 = 4;
 pub(crate) const UNBONDING_PERIOD: EraIndex = 3;
 pub(crate) const MAX_ERA_STAKE_VALUES: u32 = 8;
+pub(crate) const MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER: u32 = 4;
 
 // Do note that this needs to at least be 3 for tests to be valid. It can be greater but not smaller.
 pub(crate) const BLOCKS_PER_ERA: BlockNumber = 3;
@@ -124,6 +125,7 @@ parameter_types! {
     pub const MaxUnlockingChunks: u32 = MAX_UNLOCKING_CHUNKS;
     pub const UnbondingPeriod: EraIndex = UNBONDING_PERIOD;
     pub const MaxEraStakeValues: u32 = MAX_ERA_STAKE_VALUES;
+    pub const MaxNumberOfBeneficiariesPerStaker: u32 = MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER;
 }
 
 impl pallet_dapps_staking::Config for TestRuntime {
@@ -140,6 +142,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxUnlockingChunks = MaxUnlockingChunks;
     type UnbondingPeriod = UnbondingPeriod;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type MaxNumberOfBeneficiariesPerStaker = MaxNumberOfBeneficiariesPerStaker;
 }
 
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, scale_info::TypeInfo)]

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -896,7 +896,7 @@ pub mod pallet {
             Ok(().into())
         }
 
-        /// Register a delegated account for a staker.
+        /// delegate another account to claim rewards on behalf of the staker
         #[pallet::weight(0)]
         pub fn register_delegated_account_and_deposit_rewards(
             origin: OriginFor<T>,
@@ -944,7 +944,7 @@ pub mod pallet {
 
             // Withdraw reward funds from the dapps staking pot
             let reward_imbalance = T::Currency::withdraw(
-                &target,
+                &Self::account_id(),
                 staker_reward.clone(),
                 WithdrawReasons::TRANSFER,
                 ExistenceRequirement::AllowDeath,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -187,37 +187,10 @@ pub mod pallet {
         ValueQuery,
     >;
 
-    /// Stores the staker's reward beneficiaries
-    /// This first account is the staker's account
-    /// The second account is the beneficiary's account
-    ///
-    /// Using this illustration: ALICE -> BOB -> CAROL
-    /// If BOB is a beneficiary, the he delegates his role to CAROL, then the reward will be transferred to CAROL, and also BOB makes himself inactive and CAROL active.
-    #[pallet::storage]
-    #[pallet::getter(fn reward_beneficiaries)]
-    pub type RewardBeneficiaries<T: Config> = StorageDoubleMap<
-        _,
-        Blake2_128Concat,
-        T::AccountId,
-        Blake2_128Concat,
-        T::AccountId,
-        RewardBeneficiary<T::SmartContract, BalanceOf<T>>,
-        OptionQuery,
-    >;
-
     /// Stores the list of beneficiaries for a particular staker.
-    /// This is also used to limit the number of beneficiaries that can be stored in `RewardBeneficiaries` map.
-    #[pallet::storage]
-    #[pallet::getter(fn staker_beneficiaries)]
-    pub type StakerBeneficiaries<T: Config> = StorageMap<
-        _,
-        Blake2_128Concat,
-        T::AccountId,
-        Vec<BeneficiaryInfo<T::AccountId>>,
-        ValueQuery,
-    >;
-
-    /// Stores the list of beneficiaries for a particular staker.
+    /// `T::AccountId` is the staker account Id.
+    /// `T::SmartContract` is the smart contract Id.
+    /// `BeneficiaryReward` contains the account Id of the beneficiary and the amount deposited into the beneficiary's account this is used to track the amount each beneficiary has received for future operations.
     #[pallet::storage]
     #[pallet::getter(fn beneficiaries)]
     pub type Beneficiaries<T: Config> = StorageDoubleMap<
@@ -1029,6 +1002,7 @@ pub mod pallet {
         /// `origin` - The first beneficiary, BOB
         /// `original_staker` - The original staker, ALICE
         /// `target` - The new beneficiary, CAROL
+        /// `contract_id` - The contract id
         /// We need the original staker in order to get the beneficiary info
         #[pallet::weight(0)]
         pub fn deposit_rewards_to_second_beneficiary_and_register_second_beneficiary(
@@ -1088,9 +1062,8 @@ pub mod pallet {
         }
 
         /// Transfer rewards to a new beneficiary and register a new beneficiary, this is done by ALICE
-        /// ALICE decides to make BOB inactive and CAROL active and also transfer the rewards to CAROL
         /// `origin` - The original staker, ALICE
-        /// `old_beneficiary` - The first beneficiary, BOB
+        /// `contract_id` - contract id
         /// `new_beneficiary` - The new beneficiary, CAROL
         #[pallet::weight(0)]
         pub fn change_beneficiary(

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -370,12 +370,19 @@ pub mod pallet {
         NotActiveStaker,
         /// Transfering nomination to the same contract
         NominationTransferToSameContract,
+        /// Invalid staker
         InvalidStaker,
+        /// Max number of beneficiaries reached
         MaxBeneficiariesReached,
+        /// Beneficiary already exists for this staker
         BeneficiaryAlreadyExists,
+        /// Beneficiary not found
         BeneficiaryNotFound,
+        /// Beneficiary already has a second beneficiary
         BeneficiaryAlreadyHasSecondBeneficiary,
+        /// Wrong beneficiary for this staker
         InvalidBeneficiary,
+        /// Beneficiary is not active 
         BeneficiaryNotActive,
     }
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -586,7 +586,9 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
     );
 }
 
-/// Used to perform claim for stakers with success assertion
+/// Used to perform claim for stakers and deposit the rewards into a delgated beneficiary, with success assertion
+/// The beneficiary is also recorded in storage `RewardBeneficiaries` contains a double map of `staker` and `direct beneficiary` and the value is the `beneficiary` info which records the amount deposited into the beneficiary account and also a next beneficiary.
+/// Using this illustration: /// i.e ALICE -> BOB
 pub(crate) fn assert_recieve_claim_rewards_for_staker(
     claimer: AccountId,
     contract_id: &MockSmartContract<AccountId>,
@@ -617,36 +619,28 @@ pub(crate) fn assert_recieve_claim_rewards_for_staker(
         assert!(unregistered_era > claim_era);
     }
 
+    // Rewards calculation
     let calculated_reward =
         Perbill::from_rational(staked, init_state_claim_era.contract_info.total)
             * stakers_joint_reward;
     let issuance_before_claim = <TestRuntime as Config>::Currency::total_issuance();
 
-    assert_ok!(
-        DappsStaking::register_delegated_account_and_deposit_rewards(
-            Origin::signed(claimer),
-            contract_id.clone(),
-            target.clone(),
-        )
-    );
+    // register first beneficiary and deposit rewards to it
+    assert_ok!(DappsStaking::deposit_rewards_and_delegate_beneficiary(
+        Origin::signed(claimer),
+        contract_id.clone(),
+        target.clone(),
+    ));
+
+    // println!("reward: {:?}", calculated_reward);
+
     // test balance of beneficiary
     assert_eq!(
         first_balance + calculated_reward,
         <TestRuntime as Config>::Currency::free_balance(&target)
     );
 
-    // println!("first_balance: {:?} claimer balance {:?}", first_balance, claimer);
-    // println!(
-    //     "second_balance: {:?} reward: {:?}",
-    //     <TestRuntime as Config>::Currency::free_balance(&target), calculated_reward
-    // );
-
     let final_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
-
-    // println!(
-    //     "final_state_current_era: {:?}",
-    //     final_state_current_era.ledger.reward_destination
-    // );
 
     // restake shouldn't be performed
     assert_eq!(
@@ -664,7 +658,7 @@ pub(crate) fn assert_recieve_claim_rewards_for_staker(
         init_state_current_era.staker_info.latest_staked_value(),
     ) {
         // There should be only 1 event, ClaimRewardsAndDepositToBeneficiary
-        // if there's less, panic is acceptable
+        // if there's less or more, panic is acceptable
         let events = dapps_staking_events();
         // println!("print events {:#?}", events);
         let last_event = &events[events.len() - 1];
@@ -680,7 +674,7 @@ pub(crate) fn assert_recieve_claim_rewards_for_staker(
         );
     }
 
-    // last event should be laimRewardsAndDepositToBeneficiary, regardless of restaking
+    // last event should be laimRewardsAndDepositToBeneficiary
     System::assert_last_event(mock::Event::DappsStaking(
         Event::ClaimRewardsAndDepositToBeneficiary(
             claimer,
@@ -715,6 +709,216 @@ pub(crate) fn assert_recieve_claim_rewards_for_staker(
         final_state_claim_era.contract_info
     );
 }
+
+pub(crate) fn assert_registered_second_beneficiary(
+    claimer: AccountId,
+    first_beneficiary: AccountId,
+    second_beneficiary: AccountId,
+) {
+    //clean up possible leftover events
+    System::reset_events();
+
+    // check if the first beneficiary is not the same as the second beneficiary
+    assert!(
+        first_beneficiary != second_beneficiary,
+        "first beneficiary and second beneficiary are the same"
+    );
+
+    // check if the `first_beneficiary` field is actually the beneficiary of the staker
+    assert_eq!(
+        DappsStaking::reward_beneficiaries(&claimer, &first_beneficiary).is_some(),
+        true,
+    );
+
+    // unwrap is safe here because we know that the `first_beneficiary` is a beneficiary of the staker
+
+    DappsStaking::reward_beneficiaries(&claimer, &first_beneficiary).unwrap();
+
+    assert_ok!(
+        DappsStaking::deposit_rewards_to_second_beneficiary_and_register_second_beneficiary(
+            Origin::signed(first_beneficiary),
+            claimer.clone(),
+            second_beneficiary.clone(),
+        )
+    );
+}
+
+pub(crate) fn assert_change_beneficiary(
+    staker: AccountId,
+    old_beneficiary: AccountId,
+    new_beneficiary: AccountId,
+) {
+    //clean up possible leftover events
+    System::reset_events();
+
+    // check if the `old_beneficiary` field is actually the beneficiary of the staker
+    assert_eq!(
+        DappsStaking::reward_beneficiaries(&staker, &old_beneficiary).is_some(),
+        true,
+    );
+
+    // assert!(list_of_beneficiaries.contains(&old_beneficiary));
+
+    assert_ok!(DappsStaking::change_beneficiary(
+        Origin::signed(staker),
+        old_beneficiary.clone(),
+        new_beneficiary.clone(),
+    ));
+
+    let list_of_beneficiaries = DappsStaking::staker_beneficiaries(&staker);
+
+    // check if the `new_beneficiary` field is now the beneficiary of the staker
+    assert_eq!(
+        DappsStaking::reward_beneficiaries(&staker, &new_beneficiary).is_some(),
+        true,
+    );
+
+    println!(
+        "just wtf is going on here? {:#?} old {:#?}",
+        list_of_beneficiaries, old_beneficiary
+    );
+    println!(
+        "reward b_info {:#?}",
+        DappsStaking::reward_beneficiaries(&staker, &old_beneficiary)
+    );
+
+    // check if the `old_beneficiary` field is no longer the beneficiary of the staker
+    // assert_eq!(
+    //     DappsStaking::reward_beneficiaries(&staker, &old_beneficiary).is_none(),
+    //     true,
+    // );
+
+    assert_eq!(
+        list_of_beneficiaries
+            .iter()
+            .any(|x| { x.account == new_beneficiary }),
+        true
+    );
+}
+
+/// Used to perform claim for stakers and deposit the rewards into a delgated beneficiary, with success assertion
+/// The beneficiary is also recorded in storage `RewardBeneficiaries` contains a double map of `staker` and `direct beneficiary` and the value is the `beneficiary` info which records the amount deposited into the beneficiary account and also a next beneficiary.
+/// Using this illustration: /// i.e ALICE -> BOB -> CAROL
+// pub(crate) fn assert_second_beneficiary_can_claim_rewards_for_staker(
+//     claimer: AccountId,
+//     contract_id: &MockSmartContract<AccountId>,
+//     target: AccountId,
+// ) {
+//     let (claim_era, _) = DappsStaking::staker_info(&claimer, contract_id).claim();
+//     let current_era = DappsStaking::current_era();
+
+//     let first_balance = <TestRuntime as Config>::Currency::free_balance(&target);
+
+//     //clean up possible leftover events
+//     System::reset_events();
+
+//     let init_state_claim_era = MemorySnapshot::all(claim_era, contract_id, claimer);
+//     let init_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
+
+//     // Calculate contract portion of the reward
+//     let (_, stakers_joint_reward) = DappsStaking::dev_stakers_split(
+//         &init_state_claim_era.contract_info,
+//         &init_state_claim_era.era_info,
+//     );
+
+//     let (claim_era, staked) = init_state_claim_era.staker_info.clone().claim();
+//     assert!(claim_era > 0); // Sanity check - if this fails, method is being used incorrectly
+
+//     // Cannot claim rewards post unregister era, this indicates a bug!
+//     if let DAppState::Unregistered(unregistered_era) = init_state_claim_era.dapp_info.state {
+//         assert!(unregistered_era > claim_era);
+//     }
+
+//     // Rewards calculation
+//     let calculated_reward =
+//         Perbill::from_rational(staked, init_state_claim_era.contract_info.total)
+//             * stakers_joint_reward;
+//     let issuance_before_claim = <TestRuntime as Config>::Currency::total_issuance();
+
+//     // register first beneficiary and deposit rewards to it
+//     assert_ok!(DappsStaking::deposit_rewards_to_delegated_beneficiary(
+//         Origin::signed(claimer),
+//         contract_id.clone(),
+//         target.clone(),
+//     ));
+
+//     // println!("reward: {:?}", calculated_reward);
+
+//     // test balance of beneficiary
+//     assert_eq!(
+//         first_balance + calculated_reward,
+//         <TestRuntime as Config>::Currency::free_balance(&target)
+//     );
+
+//     let final_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
+
+//     // restake shouldn't be performed
+//     assert_eq!(
+//         DappsStaking::should_restake_reward(
+//             final_state_current_era.ledger.reward_destination,
+//             final_state_current_era.dapp_info.state,
+//             final_state_current_era.staker_info.latest_staked_value()
+//         ),
+//         false
+//     );
+
+//     if DappsStaking::should_restake_reward(
+//         init_state_current_era.ledger.reward_destination,
+//         init_state_current_era.dapp_info.state,
+//         init_state_current_era.staker_info.latest_staked_value(),
+//     ) {
+//         // There should be only 1 event, ClaimRewardsAndDepositToBeneficiary
+//         // if there's less or more, panic is acceptable
+//         let events = dapps_staking_events();
+//         // println!("print events {:#?}", events);
+//         let last_event = &events[events.len() - 1];
+//         assert_eq!(
+//             last_event.clone(),
+//             Event::<TestRuntime>::ClaimRewardsAndDepositToBeneficiary(
+//                 claimer,
+//                 contract_id.clone(),
+//                 claim_era,
+//                 calculated_reward,
+//                 target.clone()
+//             )
+//         );
+//     }
+
+//     // last event should be laimRewardsAndDepositToBeneficiary
+//     System::assert_last_event(mock::Event::DappsStaking(
+//         Event::ClaimRewardsAndDepositToBeneficiary(
+//             claimer,
+//             contract_id.clone(),
+//             claim_era,
+//             calculated_reward,
+//             target.clone(),
+//         ),
+//     ));
+
+//     let (new_era, _) = final_state_current_era.staker_info.clone().claim();
+//     if final_state_current_era.staker_info.is_empty() {
+//         assert!(new_era.is_zero());
+//         assert!(!GeneralStakerInfo::<TestRuntime>::contains_key(
+//             &claimer,
+//             contract_id
+//         ));
+//     } else {
+//         // println!("new_era: {:?} claim_era: {:?}", new_era, claim_era);
+//         assert!(new_era > claim_era);
+//     }
+//     assert!(new_era.is_zero() || new_era > claim_era);
+
+//     // Claim shouldn't mint new tokens, instead it should just transfer from the dapps staking pallet account
+//     let issuance_after_claim = <TestRuntime as Config>::Currency::total_issuance();
+//     assert_eq!(issuance_before_claim, issuance_after_claim);
+
+//     // // Old `claim_era` contract info should never be changed
+//     let final_state_claim_era = MemorySnapshot::all(claim_era, contract_id, claimer);
+//     assert_eq!(
+//         init_state_claim_era.contract_info,
+//         final_state_claim_era.contract_info
+//     );
+// }
 
 // assert staked and locked states depending on should_restake_reward
 // returns should_restake_reward result so further checks can be made

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -782,125 +782,31 @@ pub(crate) fn assert_change_beneficiary(
 }
 
 pub(crate) fn assert_use_saved_beneficiary_to_receive_awards(
-    claimer: AccountId,
+    staker: AccountId,
     contract_id: &MockSmartContract<AccountId>,
-    target: AccountId,
+    beneficiary: AccountId,
 ) {
-    let (claim_era, _) = DappsStaking::staker_info(&claimer, contract_id).claim();
-    let current_era = DappsStaking::current_era();
-
-    let first_balance = <TestRuntime as Config>::Currency::free_balance(&target);
-
     //clean up possible leftover events
     System::reset_events();
 
-    let init_state_claim_era = MemorySnapshot::all(claim_era, contract_id, claimer);
-    let init_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
-
-    // Calculate contract portion of the reward
-    let (_, stakers_joint_reward) = DappsStaking::dev_stakers_split(
-        &init_state_claim_era.contract_info,
-        &init_state_claim_era.era_info,
+    // check if the `old_beneficiary` field is actually the beneficiary of the staker
+    assert_eq!(
+        DappsStaking::reward_beneficiaries(&staker, &beneficiary).is_some(),
+        true,
     );
 
-    let (claim_era, staked) = init_state_claim_era.staker_info.clone().claim();
-    assert!(claim_era > 0); // Sanity check - if this fails, method is being used incorrectly
+    // assert!(list_of_beneficiaries.contains(&old_beneficiary));
 
-    // Cannot claim rewards post unregister era, this indicates a bug!
-    if let DAppState::Unregistered(unregistered_era) = init_state_claim_era.dapp_info.state {
-        assert!(unregistered_era > claim_era);
-    }
-
-    // Rewards calculation
-    let calculated_reward =
-        Perbill::from_rational(staked, init_state_claim_era.contract_info.total)
-            * stakers_joint_reward;
-    let issuance_before_claim = <TestRuntime as Config>::Currency::total_issuance();
-
-    // register first beneficiary and deposit rewards to it
     assert_ok!(DappsStaking::use_saved_beneficiary_to_receive_rewards(
-        Origin::signed(claimer),
-        target.clone(),
+        Origin::signed(staker),
+        beneficiary.clone(),
         contract_id.clone(),
     ));
 
-    // println!("reward: {:?}", calculated_reward);
+    let list_of_beneficiaries = DappsStaking::staker_beneficiaries(&staker);
 
-    // test balance of beneficiary
-    assert_eq!(
-        first_balance + calculated_reward,
-        <TestRuntime as Config>::Currency::free_balance(&target)
-    );
-
-    let final_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
-
-    // restake shouldn't be performed
-    assert_eq!(
-        DappsStaking::should_restake_reward(
-            final_state_current_era.ledger.reward_destination,
-            final_state_current_era.dapp_info.state,
-            final_state_current_era.staker_info.latest_staked_value()
-        ),
-        false
-    );
-
-    if DappsStaking::should_restake_reward(
-        init_state_current_era.ledger.reward_destination,
-        init_state_current_era.dapp_info.state,
-        init_state_current_era.staker_info.latest_staked_value(),
-    ) {
-        // There should be only 1 event, ClaimRewardsAndDepositToBeneficiary
-        // if there's less or more, panic is acceptable
-        let events = dapps_staking_events();
-        // println!("print events {:#?}", events);
-        let last_event = &events[events.len() - 1];
-        assert_eq!(
-            last_event.clone(),
-            Event::<TestRuntime>::ClaimRewardsAndDepositToBeneficiary(
-                claimer,
-                contract_id.clone(),
-                claim_era,
-                calculated_reward,
-                target.clone()
-            )
-        );
-    }
-
-    // last event should be ClaimRewardsAndDepositToBeneficiary
-    System::assert_last_event(mock::Event::DappsStaking(
-        Event::ClaimRewardsAndDepositToBeneficiary(
-            claimer,
-            contract_id.clone(),
-            claim_era,
-            calculated_reward,
-            target.clone(),
-        ),
-    ));
-
-    let (new_era, _) = final_state_current_era.staker_info.clone().claim();
-    if final_state_current_era.staker_info.is_empty() {
-        assert!(new_era.is_zero());
-        assert!(!GeneralStakerInfo::<TestRuntime>::contains_key(
-            &claimer,
-            contract_id
-        ));
-    } else {
-        assert!(new_era > claim_era);
-    }
-    assert!(new_era.is_zero() || new_era > claim_era);
-
-    // Claim shouldn't mint new tokens, instead it should just transfer from the dapps staking pallet account
-    let issuance_after_claim = <TestRuntime as Config>::Currency::total_issuance();
-    assert_eq!(issuance_before_claim, issuance_after_claim);
-
-    // // Old `claim_era` contract info should never be changed
-    let final_state_claim_era = MemorySnapshot::all(claim_era, contract_id, claimer);
-    assert_eq!(
-        init_state_claim_era.contract_info,
-        final_state_claim_era.contract_info
-    );
-
-    // assert_eq!(staker_info.beneficiary, beneficiary);
+    // check if the `beneficiary` field is now removed from the list of beneficiaries
+    assert_eq!(list_of_beneficiaries.is_empty(), false);
 }
 
 pub(crate) fn assert_remove_beneficiary(staker: AccountId, beneficiary: AccountId) {

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2123,6 +2123,94 @@ fn reset_delegation() {
 }
 
 #[test]
+fn use_old_beneficiary_ok() {}
+
+#[test]
+fn remove_beneficiary() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let first_developer = 1;
+        let second_developer = 2;
+        let first_staker = 3;
+        let second_staker = 4;
+        let beneficiary = 6_u64;
+        let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
+
+        let start_era = DappsStaking::current_era();
+
+        let beneficiary_balance_before = Balances::free_balance(&beneficiary);
+
+        // Prepare a scenario with different stakes
+
+        assert_register(first_developer, &first_contract_id);
+        assert_register(second_developer, &second_contract_id);
+        assert_bond_and_stake(first_staker, &first_contract_id, 100);
+        assert_bond_and_stake(second_staker, &first_contract_id, 45);
+
+        // Just so ratio isn't 100% in favor of the first contract
+        assert_bond_and_stake(first_staker, &second_contract_id, 33);
+        assert_bond_and_stake(second_staker, &second_contract_id, 22);
+
+        let eras_advanced = 3;
+        advance_to_era(start_era + eras_advanced);
+
+        for x in 0..eras_advanced.into() {
+            assert_bond_and_stake(first_staker, &first_contract_id, 20 + x * 3);
+            assert_bond_and_stake(second_staker, &first_contract_id, 5 + x * 5);
+            advance_to_era(DappsStaking::current_era() + 1);
+        }
+
+        // Claim rewards
+        // Ensure that all past eras can be claimed
+        let current_era = DappsStaking::current_era();
+        for era in start_era..current_era {
+            assert_recieve_claim_rewards_for_staker(first_staker, &first_contract_id, beneficiary);
+            assert_claim_dapp(&first_contract_id, era);
+            assert_claim_staker(second_staker, &first_contract_id);
+        }
+
+        // reset beneficiary to staker first
+        assert_ok!(
+            DappsStaking::reset_rewards_deposited_into_beneficiary_back_to_staker(
+                Origin::signed(first_staker),
+                beneficiary
+            ),
+        );
+
+        // beneficiary balance after resetting the stash location
+        assert!(
+            Balances::free_balance(&beneficiary) == beneficiary_balance_before,
+            "beneficiary should recieve rewards"
+        );
+
+        assert!(
+            RewardBeneficiaries::<TestRuntime>::get(&first_staker, &beneficiary)
+                .unwrap()
+                .amount
+                == 0
+        );
+
+        // Change beneficiary
+        assert_remove_beneficiary(first_staker.clone(), beneficiary);
+
+        // Check if the beneficiary recieves the rewards
+        assert_eq!(
+            RewardBeneficiaries::<TestRuntime>::get(&first_staker, &beneficiary).is_some(),
+            false
+        );
+
+        assert!(
+            StakerBeneficiaries::<TestRuntime>::get(&first_staker)
+                .iter()
+                .any(|f| f.account == beneficiary)
+                == false
+        );
+    })
+}
+
+#[test]
 fn claim_after_unregister_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1703,6 +1703,66 @@ fn claim_is_ok() {
 }
 
 #[test]
+fn delegate_claim() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let first_developer = 1;
+        let second_developer = 2;
+        let first_staker = 3;
+        let second_staker = 4;
+        let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
+
+        let start_era = DappsStaking::current_era();
+
+        // Prepare a scenario with different stakes
+
+        assert_register(first_developer, &first_contract_id);
+        assert_register(second_developer, &second_contract_id);
+        assert_bond_and_stake(first_staker, &first_contract_id, 100);
+        assert_bond_and_stake(second_staker, &first_contract_id, 45);
+
+        // Just so ratio isn't 100% in favor of the first contract
+        assert_bond_and_stake(first_staker, &second_contract_id, 33);
+        assert_bond_and_stake(second_staker, &second_contract_id, 22);
+
+        let eras_advanced = 3;
+        advance_to_era(start_era + eras_advanced);
+
+        for x in 0..eras_advanced.into() {
+            assert_bond_and_stake(first_staker, &first_contract_id, 20 + x * 3);
+            assert_bond_and_stake(second_staker, &first_contract_id, 5 + x * 5);
+            advance_to_era(DappsStaking::current_era() + 1);
+        }
+
+        // Ensure that all past eras can be claimed
+        let current_era = DappsStaking::current_era();
+        for era in start_era..current_era {
+            assert_claim_staker(first_staker, &first_contract_id);
+            assert_claim_dapp(&first_contract_id, era);
+            assert_claim_staker(second_staker, &first_contract_id);
+        }
+
+        // Shouldn't be possible to claim current era.
+        // Also, previous claim calls should have claimed everything prior to current era.
+        assert_noop!(
+            DappsStaking::claim_staker(Origin::signed(first_staker), first_contract_id.clone()),
+            Error::<TestRuntime>::EraOutOfBounds
+        );
+        assert_noop!(
+            DappsStaking::claim_dapp(
+                Origin::signed(first_developer),
+                first_contract_id,
+                current_era
+            ),
+            Error::<TestRuntime>::EraOutOfBounds
+        );
+    })
+}
+
+
+#[test]
 fn claim_after_unregister_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/precompiles/dapps-staking/DappsStaking.sol
+++ b/precompiles/dapps-staking/DappsStaking.sol
@@ -79,4 +79,6 @@ interface DappsStaking {
     /// @param amount amount to transfer from origin to target
     /// @param target_smart_contract target smart contract address
     function nomination_transfer(address origin_smart_contract, uint128 amount, address target_smart_contract) external;
+
+    //TODO: add created extrinsics here
 }

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -28,8 +28,6 @@ type BalanceOf<Runtime> = <<Runtime as pallet_dapps_staking::Config>::Currency a
     <Runtime as frame_system::Config>::AccountId,
 >>::Balance;
 
-type AccountOf<Runtime> = <Runtime as frame_system::Config>::AccountId;
-
 #[cfg(test)]
 mod mock;
 #[cfg(test)]

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -40,6 +40,7 @@ pub(crate) const MINIMUM_REMAINING_AMOUNT: Balance = 1;
 pub(crate) const MAX_UNLOCKING_CHUNKS: u32 = 4;
 pub(crate) const UNBONDING_PERIOD: EraIndex = 3;
 pub(crate) const MAX_ERA_STAKE_VALUES: u32 = 10;
+pub(crate) const MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER: u32 = 4;
 
 // Do note that this needs to at least be 3 for tests to be valid. It can be greater but not smaller.
 pub(crate) const BLOCKS_PER_ERA: BlockNumber = 3;
@@ -265,6 +266,7 @@ parameter_types! {
     pub const MaxUnlockingChunks: u32 = MAX_UNLOCKING_CHUNKS;
     pub const UnbondingPeriod: EraIndex = UNBONDING_PERIOD;
     pub const MaxEraStakeValues: u32 = MAX_ERA_STAKE_VALUES;
+    pub const MaxNumberOfBeneficiariesPerStaker: u32 = MAX_NUMBER_OF_BENEFICIARIES_PER_STAKER;
 }
 
 impl pallet_dapps_staking::Config for TestRuntime {
@@ -281,6 +283,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxUnlockingChunks = MaxUnlockingChunks;
     type UnbondingPeriod = UnbondingPeriod;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type MaxNumberOfBeneficiariesPerStaker = MaxNumberOfBeneficiariesPerStaker;
 }
 
 pub struct ExternalityBuilder {

--- a/precompiles/dapps-staking/src/tests.rs
+++ b/precompiles/dapps-staking/src/tests.rs
@@ -492,6 +492,7 @@ fn set_reward_destination_verify(staker: TestAccount, reward_destination: Reward
     let reward_destination_raw: u8 = match reward_destination {
         RewardDestination::FreeBalance => 0,
         RewardDestination::StakeBalance => 1,
+        RewardDestination::BeneficiaryBalance => 2,
     };
     precompiles()
         .prepare_test(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-05-11"
+channel = "nightly-2022-09-20"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
**Pull Request Summary**

**Check list**
- [x] Add feature Reward Beneficiary Delegation
- [x] Added unit tests
- [x] Added new types and storage
- [x] Update toolchain to stable version
- [x] Update docs
- [ ] bencmarking 


#### About this pull request

When staker claims rewards for a contract, we want to provide an option to deposit rewards to a delegate account. E.g. Alice claims rewards and they are deposited to Bob's account.


**Storages**

- `pub type RewardBeneficiaries` -> This is a storage double map that contains `staker(AccountId) -> beneficiary (AccountId) -> RewardBeneficiary (contains info on each beneficiary)`
- `RewardBeneficiary` (contains info on each beneficiary)
Since a storagedouble map hashes both keys to give a unique key, a staker can store different beneficiaries.
- `StakerBeneficiaries` -> This is a convenient storage map that contains `staker(AccountId) -> Vec<BeneficiaryInfo> (contains info on each beneficiary)` 
This is a convenient structure for storing and listing all beneficiaries for each staker and also limits the beneficiaries per staker.

- `BeneficiaryInfo` (contains info on each beneficiary)

When a beneficiary is delegated, he is set active and the rewards are deposited into his account and the amount is also recorded in storage. When a beneficiary delegates another account, all the rewards are transferred to the delegated account and the delegated account info is created and stored. i.e when BOB -> CAROL.

If BOB wants to delegate CAROL to receive the funds instead, BOB is set inactive and the funds are transferred to CAROL

When ALICE wants her funds back from CAROL (which is now the new beneficiary), She can transfer the funds back to herself. 

Note that the first beneficiary no longer holds the funds, the contract id, the staker was rewarded from and is set inactive.

ALICE can also remove a beneficiary from her list. 

TODOs
 - [ ] benchmarking

